### PR TITLE
Updated CForm.php - check always calling the callIfSuccess handler

### DIFF
--- a/src/HTMLForm/CForm.php
+++ b/src/HTMLForm/CForm.php
@@ -575,11 +575,11 @@ EOD;
                 throw new \Exception("CForm, success-method is not callable.");
             }
     
-        } elseif ($ret === false && isset($callIfSuccess)) {
+        } elseif ($ret === false && isset($callIfFail)) {
     
             // Use callback for fail, if defined
-            if (is_callable($callIfSuccess)) {
-                call_user_func_array($callIfSuccess, [$this]);
+            if (is_callable($callIfFail)) {
+                call_user_func_array($callIfFail, [$this]);
             } else {
                 throw new \Exception("CForm, success-method is not callable.");
             }


### PR DESCRIPTION
The check method was always calling the callIfSuccess handler. I changed it to call the callIfFail handler if the check fails
