### PR TITLE
Check if $_SESSION['form-failed'] is set before unsetting

### DIFF
--- a/src/HTMLForm/CForm.php
+++ b/src/HTMLForm/CForm.php
@@ -424,7 +424,8 @@ EOD;
         $request = null;
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             $request = $_POST;
-            unset($_SESSION['form-failed']);
+            if (isset($_SESSION['form-failed']))
+                unset($_SESSION['form-failed']);
             $validates = true;
 
             foreach ($this->elements as $element) {


### PR DESCRIPTION
Error due $_SESSION['form-failed'] is not set when trying to unset.
